### PR TITLE
Feature #8: Add --exclude-comments|-e flag to not include comments in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ The upstream issue is tracked [here](https://openradar.appspot.com/22133811).
 ## Usage
 
 ```
-SwiftGenStrings [<files> ...] [-s <substitute>] [-o <output-directory>]
+USAGE: SwiftGenStrings <files> ... [-s <s>] [-o <o>] [--exclude-comments]
 
 ARGUMENTS:
-  <files>                 List of files, that are used as source of Localizable.strings generation.
+  <files>                 List of files, that are used as source of
+                          Localizable.strings generation.
 
 OPTIONS:
-  -s <substitute>         (Optional) Substitute for NSLocalizedString, useful when different macro is used.
-  -o <output-directory>   (Optional) Specifies what directory Localizable.strings table is created in. Not specifying output directory will print script output content
-                          to standard output (console).
+  -s <s>                  (Optional) Substitute for NSLocalizedString, useful when different macro is used.
+  -o <o>                  (Optional) Specifies what directory Localizable.strings table is created in. Not specifying output directory will print script output
+                          content to standard output (console).
+  -e, --exclude-comments  (Optional) Formatted output does not include comments
   --version               Show the version.
   -h, --help              Show help information.
 ```

--- a/Sources/SwiftGenStrings/SwiftGenStrings.swift
+++ b/Sources/SwiftGenStrings/SwiftGenStrings.swift
@@ -30,6 +30,9 @@ struct SwiftGenStrings: ParsableCommand {
     @Option(name: .short, help: "(Optional) Specifies what directory Localizable.strings table is created in. Not specifying output directory will print script output content to standard output (console).")
     var outputDirectory: URL?
 
+    @Flag(name: .shortAndLong, help: "(Optional) Formatted output does not include comments")
+    var excludeComments: Bool = false
+
     // MARK: - Processing
 
     func run() throws {
@@ -64,7 +67,7 @@ struct SwiftGenStrings: ParsableCommand {
             throw NSError(description: errorMessage)
         }
 
-        let output = finalStrings.formattedContent
+        let output = finalStrings.formattedContent(includeComments: !excludeComments)
 
         if let outputDirectory = outputDirectory {
             let outputFileURL = outputDirectory.appendingPathComponent("Localizable.strings")

--- a/Sources/SwiftGenStringsCore/CharacterIterator.swift
+++ b/Sources/SwiftGenStringsCore/CharacterIterator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class CharacterIterator {
+public final class CharacterIterator {
 
     private let characters: [Character]
 

--- a/Sources/SwiftGenStringsCore/LocalizedString.swift
+++ b/Sources/SwiftGenStringsCore/LocalizedString.swift
@@ -18,7 +18,7 @@ private let formatSpecifierRegex: NSRegularExpression = {
     return try! NSRegularExpression(pattern: pattern, options:[])
 }()
 
-public class LocalizedString: CustomStringConvertible, Equatable {
+public final class LocalizedString: CustomStringConvertible, Equatable {
 
     let key: String
     let value: String
@@ -45,9 +45,13 @@ public class LocalizedString: CustomStringConvertible, Equatable {
         return result as String
     }
 
-    var formatted: String {
-        "/* \(formattedComments) */\n" +
-            "\"\(key)\" = \"\(valueWithIndexedPlaceholders)\";"
+    func formatted(includeComments: Bool) -> String {
+        var result = ""
+        if includeComments {
+            result = "/* \(formattedComments) */\n"
+        }
+        result += "\"\(key)\" = \"\(valueWithIndexedPlaceholders)\";"
+        return result
     }
 
     private var formattedComments: String {

--- a/Sources/SwiftGenStringsCore/LocalizedString.swift
+++ b/Sources/SwiftGenStringsCore/LocalizedString.swift
@@ -18,17 +18,11 @@ private let formatSpecifierRegex: NSRegularExpression = {
     return try! NSRegularExpression(pattern: pattern, options:[])
 }()
 
-public final class LocalizedString: CustomStringConvertible, Equatable {
+public struct LocalizedString: CustomStringConvertible, Equatable {
 
     let key: String
     let value: String
     let comments: [String]
-
-    init(key: String, value: String, comments: [String]) {
-        self.key = key
-        self.value = value
-        self.comments = comments
-    }
 
     var valueWithIndexedPlaceholders: String {
         let matches = formatSpecifierRegex.matches(in: value, options:[], range: NSRange(location: 0, length: (value as NSString).length))
@@ -62,12 +56,6 @@ public final class LocalizedString: CustomStringConvertible, Equatable {
 
     public var description: String {
         "LocalizedString(key: \(key), value: \(value), comments: \(comments))"
-    }
-
-    // MARK: - Equatable
-
-    public static func ==(lhs: LocalizedString, rhs: LocalizedString) -> Bool {
-        lhs.key == rhs.key && lhs.value == rhs.value && lhs.comments == rhs.comments
     }
 
 }

--- a/Sources/SwiftGenStringsCore/LocalizedStringCollection.swift
+++ b/Sources/SwiftGenStringsCore/LocalizedStringCollection.swift
@@ -4,7 +4,7 @@ public protocol LocalizedStringCollectionErrorOutput {
     func differentValues(forKey key: String, value1: String, value2: String)
 }
 
-public class LocalizedStringCollection {
+public final class LocalizedStringCollection {
 
     private let errorOutput: LocalizedStringCollectionErrorOutput?
 
@@ -17,6 +17,14 @@ public class LocalizedStringCollection {
     public init(strings: [LocalizedString], errorOutput: LocalizedStringCollectionErrorOutput?) {
         self.errorOutput = errorOutput
         merge(with: strings)
+    }
+
+    public func formattedContent(includeComments: Bool) -> String {
+        strings
+            .sorted(by: {$0.key < $1.key })
+            .reduce("") { result, string in
+                result + string.formatted(includeComments: includeComments) + "\n\n"
+            }
     }
 
     public func merge(with collection: LocalizedStringCollection) {
@@ -37,14 +45,6 @@ public class LocalizedStringCollection {
                 byKey[string.key] = string
             }
         }
-    }
-
-    public var formattedContent: String {
-        strings
-            .sorted(by: {$0.key < $1.key })
-            .reduce("") { result, string in
-                result + string.formatted + "\n\n"
-            }
     }
 
 }

--- a/Sources/SwiftGenStringsCore/LocalizedStringFinder.swift
+++ b/Sources/SwiftGenStringsCore/LocalizedStringFinder.swift
@@ -7,7 +7,7 @@ public protocol LocalizedStringFinderErrorOutput {
 
 private let verifyUnicodeRegex = try! NSRegularExpression(pattern: "\\\\[uU]\\{[a-fA-F0-9]+\\}", options: [])
 
-public class LocalizedStringFinder {
+public final class LocalizedStringFinder {
 
     private let routine: String
     private let errorOutput: LocalizedStringFinderErrorOutput?

--- a/Tests/SwiftGenStringsTests/CharacterIteratorTests.swift
+++ b/Tests/SwiftGenStringsTests/CharacterIteratorTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftGenStringsCore
 import XCTest
 
-class CharacterIteratorTests: XCTestCase {
+final class CharacterIteratorTests: XCTestCase {
 
     // MARK: - Iteration tests
     

--- a/Tests/SwiftGenStringsTests/LocalizedStringCollectionTests.swift
+++ b/Tests/SwiftGenStringsTests/LocalizedStringCollectionTests.swift
@@ -1,9 +1,21 @@
 @testable import SwiftGenStringsCore
 import XCTest
 
-class LocalizedStringCollectionTests: XCTestCase {
+final class LocalizedStringCollectionTests: XCTestCase {
 
-    fileprivate var differentValuesReported: [String] = []
+    private var differentValuesReported: [String] = []
+
+    func testFormattedContentIncludingComments() {
+        let collection = LocalizedStringCollection(strings: [LocalizedString(key: "KEY", value: "VALUE", comments: ["Comment"])], errorOutput: self)
+        let output = collection.formattedContent(includeComments: true)
+        XCTAssertEqual(output, "/* Comment */\n\"KEY\" = \"VALUE\";\n\n")
+    }
+
+    func testFormattedContentExcludingComments() {
+        let collection = LocalizedStringCollection(strings: [LocalizedString(key: "KEY", value: "VALUE", comments: ["Comment will be ignored"])], errorOutput: self)
+        let output = collection.formattedContent(includeComments: false)
+        XCTAssertEqual(output, "\"KEY\" = \"VALUE\";\n\n")
+    }
 
     func testMergeWithEmptyStrings() {
         let collection = LocalizedStringCollection(strings: [], errorOutput: self)

--- a/Tests/SwiftGenStringsTests/LocalizedStringFinderTests.swift
+++ b/Tests/SwiftGenStringsTests/LocalizedStringFinderTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftGenStringsCore
 import XCTest
 
-class LocalizedStringFinderTests: XCTestCase {
+final class LocalizedStringFinderTests: XCTestCase {
 
     func testFindStringsWithTableNameAndBundle() {
         let finder = LocalizedStringFinder()

--- a/Tests/SwiftGenStringsTests/LocalizedStringTests.swift
+++ b/Tests/SwiftGenStringsTests/LocalizedStringTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftGenStringsCore
 import XCTest
 
-class LocalizedStringTests: XCTestCase {
+final class LocalizedStringTests: XCTestCase {
 
     func testLocalizedStringWithPercent() {
         let string = LocalizedString(key: "", value: "100% Swift", comments: [])

--- a/Tests/SwiftGenStringsTests/RealWorldStringsTests.swift
+++ b/Tests/SwiftGenStringsTests/RealWorldStringsTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftGenStringsCore
 import XCTest
 
-class RealWorldStringsTests: XCTestCase {
+final class RealWorldStringsTests: XCTestCase {
 
     private let errorOutput = StubErrorOutput()
 
@@ -76,7 +76,7 @@ class RealWorldStringsTests: XCTestCase {
 
 }
 
-private class StubErrorOutput: LocalizedStringFinderErrorOutput {
+private final class StubErrorOutput: LocalizedStringFinderErrorOutput {
     var invalidIdentifiers: [String] = []
     var invalidUnicodeCodePoints: [String] = []
 

--- a/Tests/SwiftGenStringsTests/SwiftTokenizerTests.swift
+++ b/Tests/SwiftGenStringsTests/SwiftTokenizerTests.swift
@@ -1,9 +1,9 @@
 @testable import SwiftGenStringsCore
 import XCTest
 
-class SwiftTokenizerTests: XCTestCase {
+final class SwiftTokenizerTests: XCTestCase {
 
-    let tokenizer = SwiftTokenizer()
+    private let tokenizer = SwiftTokenizer()
 
     func testTokenizer() {
         let string = "func something { return NSLocalizedString(\"KEY\", value: \"Quotes in \\\" the middle\", comment: \"COMMENT\") }"


### PR DESCRIPTION
Fixes #8 – adds options to exclude comments in the formatted output. To test, run

```
swift build
.build/arm64-apple-macosx/debug/SwiftGenStrings Tests/SwiftGenStringsTests/Resources/testUnescapesDoublyEscapedUnicodeCodePoints.txt --exclude-comments
```